### PR TITLE
Week4/yeeun 해시 19

### DIFF
--- a/src/week4/yeeunSim/n19_UnfinishedRunner.java
+++ b/src/week4/yeeunSim/n19_UnfinishedRunner.java
@@ -1,4 +1,39 @@
 package week4.yeeunSim;
 
+import java.util.HashMap;
+
 public class n19_UnfinishedRunner {
+    public static void main(String[] args) {
+        String[] participant1 = {"leo", "kiki", "eden"};
+        String[] completion1 = {"eden", "kiki"};
+        System.out.println(solution(participant1, completion1));
+
+        String[] participant2 = {"marina", "josipa", "nikola", "vinko", "filipa"};
+        String[] completion2 = {"josipa", "filipa", "marina", "nikola"};
+        System.out.println(solution(participant2, completion2));
+
+        String[] participant3 = {"mislav", "stanko", "mislav", "ana"};
+        String[] completion3 = {"stanko", "ana", "mislav"};
+        System.out.println(solution(participant3, completion3));
+    }
+
+    /**
+     * 시간복잡도: O(N)
+     */
+    private static String solution(String[] participant, String[] completion) {
+        HashMap<String, Integer> hashMap = new HashMap<>();
+
+        for (String string : completion) {
+            hashMap.put(string, hashMap.getOrDefault(string, 0) + 1);
+        }
+
+        for (String string : participant) {
+            if (hashMap.getOrDefault(string, 0) == 0) {
+                return string;
+            }
+            hashMap.put(string, hashMap.get(string) - 1);
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
### ⭐ Issue 번호
Related to: #10 

### 📘 풀이한 문제
| 문제 번호| 문제 제목 |
|:----------:|:-----------:|
| **19** | 완주하지 못한 선수 |


### 📜 문제 풀이 설명
> 19. 완주하지 못한 선수
- 해시맵을 사용하여 완주자 명단 `completion`의 선수 이름과 그 횟수를 먼저 기록
- 참가자 명단 `participant`을 순회하면서, 각 선수의 횟수를 해시맵에서 1씩 감소시킴
- 순회 중 해시맵에서 값이 `0`인 선수를 발견하면, 그 선수는 완주자 명단에 없거나 이미 동명이인이 차감한 후 남은 마지막 선수이므로, 미완주자로 판단하여 반환
- 시간복잡도: **O(N)**
